### PR TITLE
update version to 3.0.2 in manifest files

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "RosettaStonks",
 	"description": "Enhances your rosetta stone performances",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"manifest_version": 3,
     "background": {
         "service_worker": "./dist/worker.esm.js"

--- a/mozilla/manifest.json
+++ b/mozilla/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "RosettaStonks",
 	"description": "Enhances your rosetta stone performances",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"manifest_version": 3,
     "background": {
         "scripts": ["./dist/worker.esm.js"]


### PR DESCRIPTION
This pull request includes version updates to the `manifest.json` files for both the Chrome and Mozilla extensions.

Version updates:

* [`chrome/manifest.json`](diffhunk://#diff-80148b4275d5dc855c37aaf293a600c2dde3efa9fba3a500e4e58e97b3da266fL4-R4): Updated the version from `3.0.1` to `3.0.2`.
* [`mozilla/manifest.json`](diffhunk://#diff-13bfd894b2936fa018e472327ed535518b30fe87640b4c92cc3a663d0d18a281L4-R4): Updated the version from `3.0.1` to `3.0.2`.