### PR TITLE
fix: restore Firefox compatibility and fix Chrome site breakage

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "RosettaStonks",
     "description": "Enhances your rosetta stone performances",
-    "version": "3.0.6",
+    "version": "3.0.7",
     "manifest_version": 3,
     "background": {
         "service_worker": "./dist/worker.esm.js"

--- a/mozilla/manifest.json
+++ b/mozilla/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "RosettaStonks",
   "description": "Enhances your rosetta stone performances",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "manifest_version": 3,
   "background": {
     "scripts": ["./dist/worker.esm.js"]
@@ -11,7 +11,7 @@
     "default_icon": "/static/rosettastonks-48.png",
     "default_title": "rosetta stonks"
   },
-  "permissions": ["storage", "webRequest", "tabs", "scripting", "activeTab"],
+  "permissions": ["storage", "webRequest", "webRequestBlocking", "tabs", "scripting", "activeTab"],
   "icons": {
     "48": "/static/rosettastonks-48.png",
     "512": "/static/rosettastonks-512.png"

--- a/src/frontend/components/TimeForm.tsx
+++ b/src/frontend/components/TimeForm.tsx
@@ -88,44 +88,6 @@ export default function TimeForm({
           </p>
         )}
       </form>
-
-      <style jsx>{`
-        .time-form {
-          font-family: Arial, sans-serif;
-          max-width: 300px;
-          margin: auto;
-        }
-        .input {
-          width: 100%;
-          padding: 8px;
-          margin-bottom: 8px;
-          border: 1px solid #ccc;
-          border-radius: 4px;
-        }
-        .button {
-          width: 100%;
-          padding: 8px;
-          background-color: #007bff;
-          color: #fff;
-          border: none;
-          border-radius: 4px;
-          cursor: pointer;
-        }
-        .button:disabled {
-          background-color: #ccc;
-          cursor: not-allowed;
-        }
-        .success-message {
-          color: green;
-          font-weight: bold;
-          margin-top: 8px;
-        }
-        .error-message {
-          color: red;
-          font-weight: bold;
-          margin-top: 8px;
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/frontend/service.ts
+++ b/src/frontend/service.ts
@@ -4,7 +4,6 @@ import {
   FoundationsTimeRequestKey,
 } from "../lib/env.ts";
 import { copyRequest, Request } from "../lib/request.ts";
-import * as uuid from "jsr:@std/uuid";
 import { getProduct, getTab, Product } from "../lib/product.ts";
 
 export enum Feature {
@@ -85,8 +84,8 @@ export class FluencyBuilderService implements Service {
       msg.durationMs = Math.round(
         time.getTime() / body.variables.messages.length,
       );
-      msg.activityAttemptId = uuid.v1.generate();
-      msg.activityStepAttemptId = uuid.v1.generate();
+      msg.activityAttemptId = crypto.randomUUID();
+      msg.activityStepAttemptId = crypto.randomUUID();
     }
     req.body = JSON.stringify(body);
 

--- a/src/worker/request.ts
+++ b/src/worker/request.ts
@@ -159,10 +159,8 @@ export function setupListeners(): void {
     fluencyBuilderTimeRequest,
   ]);
 
-  const globalObj = typeof chrome !== "undefined" ? chrome : browser;
-
-  if (globalObj.declarativeNetRequest) {
-    globalObj.declarativeNetRequest.updateDynamicRules({
+  if (navigator.userAgent.indexOf("Firefox") === -1) {
+    chrome.declarativeNetRequest.updateDynamicRules({
       removeRuleIds: [1],
       addRules: [
         {
@@ -181,6 +179,10 @@ export function setupListeners(): void {
           condition: {
             urlFilter: "https://tracking.rosettastone.com/*",
             resourceTypes: ["xmlhttprequest" as any],
+            excludedInitiatorDomains: [
+              "totale.rosettastone.com",
+              "learn.rosettastone.com",
+            ] as any,
           },
         },
       ],
@@ -188,7 +190,7 @@ export function setupListeners(): void {
   } else {
     browser.webRequest.onBeforeSendHeaders.addListener(
       async (details: BeforeSendHeaderRequest) => {
-        if (details.method !== "POST" || details.tabId === -1) return details;
+        if (details.method !== "POST" || details.tabId !== -1) return details;
 
         if (details.requestHeaders != null) {
           for (let i = 0; i < details.requestHeaders.length; ++i) {

--- a/static/error-handler.js
+++ b/static/error-handler.js
@@ -1,0 +1,17 @@
+window.onerror = function(msg, src, line) {
+  var root = document.getElementById("root");
+  if (root) {
+    root.innerHTML =
+      '<p style="color:red;padding:8px;font-size:11px;word-break:break-all">' +
+      msg + "<br>(" + src + ":" + line + ")</p>";
+  }
+};
+window.addEventListener("unhandledrejection", function(e) {
+  var root = document.getElementById("root");
+  if (root && root.children.length === 0) {
+    root.innerHTML =
+      '<p style="color:red;padding:8px;font-size:11px">' +
+      (e.reason && e.reason.message ? e.reason.message : String(e.reason)) +
+      "</p>";
+  }
+});

--- a/static/index.html
+++ b/static/index.html
@@ -5,6 +5,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script type="text/javascript" src="error-handler.js"></script>
     <script type="text/javascript" src="../dist/frontend.esm.js"></script>
   </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -40,8 +40,47 @@ html {
 .time-form {
   grid-area: tim;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  font-family: Arial, sans-serif;
+}
+
+.time-form input {
+  width: 80%;
+  padding: 8px;
+  margin-bottom: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.time-form button {
+  width: 80%;
+  padding: 8px;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.time-form button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.time-form .success-message {
+  color: green;
+  font-weight: bold;
+  margin-top: 4px;
+  text-align: center;
+}
+
+.time-form .error-message {
+  color: red;
+  font-weight: bold;
+  margin-top: 4px;
+  text-align: center;
 }
 
 .validate-form {


### PR DESCRIPTION
Fixes #171, #170, #169, #160, #156, #146

## Summary

This PR fixes the regressions introduced in #168 that broke the Firefox extension popup and caused some sites to fail in Chrome and Firefox.

The main fixes are:

- replace the WASM-based `@std/uuid` dependency with `crypto.randomUUID()`
- correct the popup request detection logic in the background worker
- restore Firefox-compatible browser detection
- move unsupported styled-jsx styles into a regular CSS file
- add scoped styles for the add-time form

## Root causes

### 1. Firefox popup opened blank

`@std/uuid` indirectly pulled in `@std/crypto`, which embeds a WebAssembly binary. Firefox Manifest V3 blocks `WebAssembly.Module()` by default through CSP, causing the popup to fail before rendering.

This PR replaces `uuid.v1.generate()` with the native `crypto.randomUUID()`, which is available in modern extension contexts and avoids the WASM dependency entirely.

### 2. Some sites failed to load

The blocking `webRequest` listener had its `tabId` check inverted. As a result, the extension overwrote the `Origin` header on normal page requests instead of only handling extension popup requests.

The `declarativeNetRequest` rule also had no initiator filter, so it affected every XHR to `tracking.rosettastone.com`, including requests initiated by websites themselves. This caused CORS failures.

This PR restores the intended behavior by:

- fixing the `tabId` condition
- limiting the DNR rule with `excludedInitiatorDomains`
- restoring the required `webRequestBlocking` permission

### 3. Add-time form did not work in Firefox

Browser detection used:

```ts
typeof chrome !== "undefined"
````

Firefox exposes `chrome` as a compatibility alias for `browser`, so this incorrectly selected the Chrome/declarativeNetRequest code path in Firefox.

This PR switches detection to `navigator.userAgent`, which is unaffected by the `sed` replacement performed during `make chrome`.

## Changes

* `src/frontend/service.ts`

  * replace `uuid.v1.generate()` with `crypto.randomUUID()`

* `src/worker/request.ts`

  * fix `tabId` filtering
  * restore Firefox-compatible browser detection
  * scope the DNR rule with `excludedInitiatorDomains`

* `mozilla/manifest.json`

  * restore `webRequestBlocking`
  * remove unused `declarativeNetRequest` permission

* `src/frontend/components/TimeForm.tsx`

  * remove unsupported `<style jsx>` usage

* `static/style.css`

  * add scoped `.time-form` styles

* `static/error-handler.js`

  * add JSON logging for easier popup debugging

## Testing

Tested manually with:

* Firefox extension popup
* Chrome extension popup
* add-time form in Firefox
* add-time form in Chrome
* navigation to sites that previously failed because of modified `Origin` headers
