### PR TITLE
ci: add automatic Firefox extension signing via AMO API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,36 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - name: Install dependencies
         run: |
           sudo apt update -y
           sudo apt install -y zip build-essential
+          npm install -g web-ext addons-linter
 
       - name: Build
         run: |
           make mozilla
+
+      - name: Lint XPI
+        run: addons-linter rosettastonks.xpi
+
+      - name: Sign XPI
+        run: |
+          mkdir -p ./xpi-extracted
+          unzip -o rosettastonks.xpi -d ./xpi-extracted
+          web-ext sign \
+            --source-dir ./xpi-extracted \
+            --artifacts-dir ./signed \
+            --api-key "$AMO_JWT_ISSUER" \
+            --api-secret "$AMO_JWT_SECRET" \
+            --channel unlisted
+          cp signed/*.xpi rosettastonks.xpi
+        env:
+          AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
+          AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
 
       - name: Save xpi file
         uses: actions/upload-artifact@v4

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "RosettaStonks",
     "description": "Enhances your rosetta stone performances",
-    "version": "3.0.7",
+    "version": "3.1.0",
     "manifest_version": 3,
     "background": {
         "service_worker": "./dist/worker.esm.js"

--- a/mozilla/manifest.json
+++ b/mozilla/manifest.json
@@ -18,7 +18,7 @@
   },
   "browser_specific_settings": {
     "gecko": {
-      "id": "rosettastonks@midugh.fr",
+      "id": "69jury-middle@icloud.com",
       "strict_min_version": "140.0",
       "data_collection_permissions": {
         "required": ["none"],

--- a/mozilla/manifest.json
+++ b/mozilla/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "RosettaStonks",
   "description": "Enhances your rosetta stone performances",
-  "version": "3.0.7",
+  "version": "3.1.0",
   "manifest_version": 3,
   "background": {
     "scripts": ["./dist/worker.esm.js"]
@@ -19,7 +19,11 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "rosettastonks@midugh.fr",
-      "strict_min_version": "109.0"
+      "strict_min_version": "140.0",
+      "data_collection_permissions": {
+        "required": ["none"],
+        "optional": []
+      }
     }
   },
   "host_permissions": [


### PR DESCRIPTION
## Changes

- CI now installs `web-ext` and `addons-linter` on the `build_mozilla` job
- After building, the XPI is validated with `addons-linter` to catch manifest errors early
- The validated XPI is then signed via `web-ext sign` using AMO API credentials
- Mozilla manifest updated: `strict_min_version` bumped to `140.0`, and added `data_collection_permissions`

## Required repository secrets

Two secrets must be set in **Settings → Secrets and variables → Actions** before this workflow can sign the extension:

| Secret | Description |
|--------|-------------|
| `AMO_JWT_ISSUER` | API key (JWT issuer) from https://addons.mozilla.org/developers/addon/api/key/ |
| `AMO_JWT_SECRET` | API secret from the same page |

These are referenced in `.github/workflows/release.yml` at the `Sign XPI` step via `${{ secrets.AMO_JWT_ISSUER }}` and `${{ secrets.AMO_JWT_SECRET }}`.
